### PR TITLE
Correct typo in 24_typical_flash_part_layout.md

### DIFF
--- a/2_design_discussion/24_typical_flash_part_layout.md
+++ b/2_design_discussion/24_typical_flash_part_layout.md
@@ -42,7 +42,7 @@ the tools for creating a compressed image and a library for decompressing the
 image must be provided. These non-standard compression, encryption, signing or
 verification mechanisms are applied to a GUIED encapsulation section. Each
 method needs a unique GUID, however the methods may be applied to images more
-than once per FD image. This is done in order to facility recovery and updates
+than once per FD image. This is done in order to facilitate recovery and updates
 (called capsules). Other areas in flash may be reserved for non-volatile (NV)
 data storage, fault tolerant working (FTW) space or vital product data (VPD)
 areas. These other regions are not defined in the PI specification, and

--- a/2_design_discussion/24_typical_flash_part_layout.md
+++ b/2_design_discussion/24_typical_flash_part_layout.md
@@ -40,7 +40,7 @@ specification defines only standard EFI compression; if other compression
 mechanisms (or verification mechanisms, such as CRC32) are required, then both
 the tools for creating a compressed image and a library for decompressing the
 image must be provided. These non-standard compression, encryption, signing or
-verification mechanisms are applied to a GUIED encapsulation section. Each
+verification mechanisms are applied to a GUIDED encapsulation section. Each
 method needs a unique GUID, however the methods may be applied to images more
 than once per FD image. This is done in order to facilitate recovery and updates
 (called capsules). Other areas in flash may be reserved for non-volatile (NV)


### PR DESCRIPTION
Update 24_typical_flash_part_layout.md

Updated the following lines in 24_typical_flash_part_layout.md:
   Line 43: GUIED -> GUIDED
   Line 45: facility -> facilitate

Contributed-under: TianoCore Contribution Agreement 1.1
Signed-off-by: Matthew Graham <matthew.graham@amd.com>